### PR TITLE
Show start duration before timer is started

### DIFF
--- a/lib/circular_countdown_timer.dart
+++ b/lib/circular_countdown_timer.dart
@@ -1,6 +1,7 @@
 library circular_countdown_timer;
 
 import 'package:flutter/material.dart';
+
 import 'custom_timer_painter.dart';
 
 /// Create a Circular Countdown Timer.
@@ -71,6 +72,9 @@ class CircularCountDownTimer extends StatefulWidget {
   /// Handles the timer start.
   final bool autoStart;
 
+  /// Show the duration time on start
+  final bool showDuration;
+
   CircularCountDownTimer(
       {required this.width,
       required this.height,
@@ -92,6 +96,7 @@ class CircularCountDownTimer extends StatefulWidget {
       this.key,
       this.isTimerTextShown = true,
       this.autoStart = true,
+      this.showDuration = false,
       this.textFormat,
       this.controller})
       : assert(width != null),
@@ -112,7 +117,9 @@ class CircularCountDownTimerState extends State<CircularCountDownTimer>
   Animation<double>? _countDownAnimation;
 
   String get time {
-    if (widget.isReverse && _controller!.isDismissed) {
+    if (_controller!.isDismissed && widget.showDuration) {
+      return _getTime(_controller!.duration!);
+    } else if (widget.isReverse && _controller!.isDismissed) {
       if (widget.textFormat == CountdownTextFormat.MM_SS) {
         return "00:00";
       } else if (widget.textFormat == CountdownTextFormat.SS) {


### PR DESCRIPTION
### Tickets
Fixes #23 

### Changes
Added an optional parameter named showDuration, which is set to false by default so that it won't affect existing behavior of the apps using this plugin. If it is set to true, it will show the timer duration before it is started