### PR TITLE
fix: invalid value for `isResumed` & `isPaused` when call pause() + resume()

### DIFF
--- a/lib/circular_countdown_timer.dart
+++ b/lib/circular_countdown_timer.dart
@@ -334,6 +334,7 @@ class CountDownController {
   void pause() {
     _state._controller?.stop(canceled: false);
     isPaused = true;
+    isResumed = false;
   }
 
   /// This Method Resumes the Countdown Timer
@@ -344,6 +345,7 @@ class CountDownController {
       _state._controller?.forward(from: _state._controller!.value);
     }
     isResumed = true;
+    isPaused = false;
   }
 
   /// This Method Restarts the Countdown Timer,


### PR DESCRIPTION
# Problems 
- when I call `controller. resume()` and next call `controller.paused()` 
- `isResumed` will equal  `true` AND  `isPaused` will equal  `true` . It makes me so confused. 
<img width="431" alt="Screen Shot 2022-08-12 at 15 54 56" src="https://user-images.githubusercontent.com/2597710/184320621-63ac64e5-0a4d-424a-a1b7-45938232cbbd.png">
I was create only one button to control the recording function, like that.


- Actually, I think we could remove one flag, but I want to keep the original code as is as much as possible  

# Changes 
- when calling `paused()`, the flag`isResumed` should change to false
- when calling `resume()`, the flag `isPaused` should change to false 

 