### PR TITLE
make animation behavior configurable

### DIFF
--- a/lib/circular_countdown_timer.dart
+++ b/lib/circular_countdown_timer.dart
@@ -75,6 +75,9 @@ class CircularCountDownTimer extends StatefulWidget {
   /// Controls (i.e Start, Pause, Resume, Restart) the Countdown Timer.
   final CountDownController? controller;
 
+  // Configures how an Circular Countdown Timer behaves when animations are disabled.
+  final AnimationBehavior animationBehavior;
+
   /// Handles the timer start.
   final bool autoStart;
 
@@ -114,6 +117,7 @@ class CircularCountDownTimer extends StatefulWidget {
     this.autoStart = true,
     this.textFormat,
     this.controller,
+    this.animationBehavior = AnimationBehavior.normal
   }) : assert(initialDuration <= duration);
 
   @override
@@ -243,6 +247,7 @@ class CircularCountDownTimerState extends State<CircularCountDownTimer>
     _controller = AnimationController(
       vsync: this,
       duration: Duration(seconds: widget.duration),
+      animationBehavior: widget.animationBehavior
     );
 
     _controller!.addStatusListener((status) {


### PR DESCRIPTION
If the platform requests to disable all animations, AnimationController reduces the duration if animationBehavior is set to normal (the default). This is not desirable in all situations and can therefore be disabled by setting the animationBehavior to AnimationBehavior.preserve See: https://api.flutter.dev/flutter/animation/AnimationBehavior.html