### PR TITLE
Timer initialization fixed

### DIFF
--- a/lib/circular_countdown_timer.dart
+++ b/lib/circular_countdown_timer.dart
@@ -185,13 +185,13 @@ class CircularCountDownTimerState extends State<CircularCountDownTimer>
     countDownController?._duration = widget.duration;
     countDownController?.isStarted.value = widget.autoStart;
 
-    if (widget.initialDuration > 0 && widget.autoStart) {
-      if (widget.isReverse) {
-        _controller?.value = 1 - (widget.initialDuration / widget.duration);
-      } else {
-        _controller?.value = (widget.initialDuration / widget.duration);
-      }
+    if (widget.isReverse) {
+      _controller?.value = 1 - (widget.initialDuration / widget.duration);
+    } else {
+      _controller?.value = (widget.initialDuration / widget.duration);
+    }
 
+    if(widget.autoStart){
       countDownController?.start();
     }
   }


### PR DESCRIPTION
When creating a timer it appeared in a finished state, now it starts in the proper initial state. For example, if isReverse and isReverseAnimation are both true the timer starts filled in instead of requiring it to be started first.

New:
<img width="176" height="174" alt="image" src="https://github.com/user-attachments/assets/60d168a0-ee58-4168-b936-4dbde1cda270" />
After starting:
<img width="167" height="171" alt="image" src="https://github.com/user-attachments/assets/7231b5b1-2fe9-4f0b-a01e-53aacb5730bc" />


Old:
<img width="174" height="170" alt="image" src="https://github.com/user-attachments/assets/c708e0d0-7c57-4357-8c27-dc93932a65e7" />
After starting:
<img width="177" height="167" alt="image" src="https://github.com/user-attachments/assets/d467b155-9dd9-42dc-9de9-2fe38cd925d4" />
